### PR TITLE
fix noisy sync logs and idle queue polling

### DIFF
--- a/server/.sqlx/query-1dc0e4515929c270d761604dcc8fd2c9bcfd7864e4ad9cb47f54af7e36850247.json
+++ b/server/.sqlx/query-1dc0e4515929c270d761604dcc8fd2c9bcfd7864e4ad9cb47f54af7e36850247.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT id as \"id!\", source as \"source!\", source_id, auto_download\n           FROM manga\n           WHERE source != 'local' AND source_id IS NOT NULL AND sync_status = 'ready'",
+  "query": "SELECT id as \"id!\", source as \"source!\", source_id, auto_download\n           FROM manga\n           WHERE source != 'local' AND source_id IS NOT NULL AND sync_status = 'ready'\n             AND EXISTS (SELECT 1 FROM user_manga WHERE manga_id = manga.id)",
   "describe": {
     "columns": [
       {
@@ -34,5 +34,5 @@
       true
     ]
   },
-  "hash": "406c7989ba1687328281424f923abe073f0af334556e31c48a67fe4731ac754c"
+  "hash": "1dc0e4515929c270d761604dcc8fd2c9bcfd7864e4ad9cb47f54af7e36850247"
 }

--- a/server/src/indexer/external.rs
+++ b/server/src/indexer/external.rs
@@ -149,6 +149,7 @@ impl Source for ExternalSource {
         let count = chapters.len();
         let now = Utc::now();
         let src_id = self.source_id.clone();
+        let mut new_count = 0usize;
 
         for ch in &chapters {
             let existing = sqlx::query_scalar!(
@@ -169,10 +170,13 @@ impl Source for ExternalSource {
                 )
                 .execute(db)
                 .await?;
+                new_count += 1;
             }
         }
 
-        tracing::info!("{}: synced {} chapters for manga {}", src_id, count, manga_id);
+        if new_count > 0 {
+            tracing::info!("{}: {} new chapters for manga {} ({} total)", src_id, new_count, manga_id, count);
+        }
         Ok(count)
     }
 

--- a/server/src/indexer/mangapill.rs
+++ b/server/src/indexer/mangapill.rs
@@ -286,7 +286,9 @@ pub async fn sync_chapters(db: &SqlitePool, manga_id: &str, source_id: &str) -> 
         }
     }
 
-    tracing::info!("mangapill: synced {} chapters for manga {} ({} new)", count, manga_id, new_count);
+    if new_count > 0 {
+        tracing::info!("mangapill: {} new chapters for manga {} ({} total)", new_count, manga_id, count);
+    }
     Ok(count)
 }
 

--- a/server/src/indexer/mod.rs
+++ b/server/src/indexer/mod.rs
@@ -71,7 +71,8 @@ pub async fn sync_library(state: &AppState) -> Result<()> {
     let mangas = sqlx::query!(
         r#"SELECT id as "id!", source as "source!", source_id, auto_download
            FROM manga
-           WHERE source != 'local' AND source_id IS NOT NULL AND sync_status = 'ready'"#
+           WHERE source != 'local' AND source_id IS NOT NULL AND sync_status = 'ready'
+             AND EXISTS (SELECT 1 FROM user_manga WHERE manga_id = manga.id)"#
     )
     .fetch_all(&state.db)
     .await?;

--- a/web/src/features/manga-detail/hooks/useMangaDetail.ts
+++ b/web/src/features/manga-detail/hooks/useMangaDetail.ts
@@ -141,13 +141,21 @@ export function useMangaDetail(id: string | undefined): MangaDetailHandle {
     return () => clearInterval(id)
   }, [manga?.sync_status, fetchChapters])
 
-  // Poll queue every 2s
+  // Fetch queue on mount
   useEffect(() => {
     if (!id) return
     fetchQueue()
+  }, [id, fetchQueue])
+
+  // Poll every 2s only while there are active items; stops automatically when idle
+  useEffect(() => {
+    const hasActive = queueItems.some(
+      (q) => q.status === 'pending' || q.status === 'downloading',
+    )
+    if (!hasActive) return
     const tid = setInterval(fetchQueue, 2000)
     return () => clearInterval(tid)
-  }, [id, fetchQueue])
+  }, [queueItems, fetchQueue])
 
   const progressMap = new Map<string, ReadProgress>(allProgress.map((p) => [p.chapter_id, p]))
   const queueMap = new Map<string, QueueItem>(queueItems.map((q) => [q.chapter_id, q]))


### PR DESCRIPTION
Indexer only syncs manga with active user_manga subscriptions — orphan rows no longer trigger background syncs. Log only when new chapters are found; silent otherwise. Wording changed to "N new chapters" to reflect actual work done.

Queue poller on manga detail page now only runs while items are pending or downloading; stops immediately when idle instead of polling every 2s unconditionally.