### PR TITLE
fix: lengthen e2e JWT_SECRET to meet HS256 128-bit minimum

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
       DATABASE_URL: sqlite:///data/arrgh.db
       DOWNLOAD_DIR: /data/downloads
       PLUGIN_URLS: "http://fixture:4001"
-      JWT_SECRET: "e2e-test-secret"
+      JWT_SECRET: "e2e-test-secret-long-enough-for-hs256"
       INDEX_INTERVAL_HOURS: "9999"
     volumes:
       - arrgh_test_data:/data


### PR DESCRIPTION
ASP.NET JWT requires >=128 bits; "e2e-test-secret" is 120 bits → 500 on register.