### PR TITLE
ci: serialise gh-pages Allure pushes across CI + E2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,11 @@ jobs:
     if: always()
     permissions:
       contents: write
+    # Serialise every gh-pages writer (this job + e2e.yml) — they race on the
+    # same branch and the loser fails with non-fast-forward.
+    concurrency:
+      group: gh-pages-allure
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Serialise every gh-pages writer (this job + ci.yml's Allure Report) —
+    # they race on the same branch and the loser fails with non-fast-forward.
+    concurrency:
+      group: gh-pages-allure
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

Every push to `main` fires `ci.yml` (Allure Report job → 1 gh-pages push) and `e2e.yml` (API + E2e job → 3 gh-pages pushes) with no `concurrency` coordination. The 4 writers race on the `gh-pages` branch; the loser fails with non-fast-forward.

Hit on #117's merge (`490df1801`) — CI failed in 13s at "Push raw unit+integration results to gh-pages cache", re-run passed. Flaky, not deterministic. Pre-existing; unrelated to that PR's contents.

## Fix

Shared job-level `concurrency: { group: gh-pages-allure, cancel-in-progress: false }` on both jobs → they queue instead of colliding. Unit-test jobs still run in parallel with E2e; only the gh-pages writers serialise.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)